### PR TITLE
More flexible slackbot integration, along with a few cosmetic template changes

### DIFF
--- a/templates/new_user.html
+++ b/templates/new_user.html
@@ -2,13 +2,12 @@
 {% include "header.html" %}
 
 
-<h1>New User</h1>
+<h1>Welcome to Weekly Snippets!</h1>
 
-<p>We have no records for <strong>{{username}}</strong>.  If you are a new
-  user, <a href="/settings?msg=Welcome!+Verify+the+settings+below+and+click+'Save'.&u={{username}}&redirect_to=snippet_entry">verify
-  your settings</a> and you can get started writing snippets!</p>
+<p>We haven't seen <strong>{{username}}</strong> here before (that's you). To get started, please <b><a href="/settings?msg=Welcome!+Verify+the+settings+below+and+click+'Save'.&u={{username}}&redirect_to=snippet_entry">verify
+  your settings</a></b> and you can get started writing snippets!</p>
 
-<p>Another possibility is you accidentally logged in as the wrong
+<p>Confused why you're seeing this? Perhaps you accidentally logged in as the wrong
   user.  You can <a href="{{login_url}}">switch users</a>,
   or <a href="{{logout_url}}">log out</a> and log back in
   as the correct user.</p>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -23,9 +23,12 @@
   <input id="category" type="text" name="category" value="{{user.category}}">
 </div>
 
+{# For simplicity of onboarding, don't show these settings: the defaults are sensible. #}
+{% if not is_new_user %}
 <fieldset class="user-settings-block">
   <legend class="user-settings-label">
     Interpret snippets as <a href="http://daringfireball.net/projects/markdown/syntax">markdown</a> by default?
+    You should almost certainly pick Yes.
   </legend>
   <input id="markdown-yes" type="radio" name="markdown" value="yes"
          {% if user.uses_markdown %}checked{% endif %}>
@@ -36,7 +39,7 @@
 </fieldset>
 
 <fieldset class="user-settings-block">
-  <legend class="user-settings-label">Have snippets be private by default?:</legend>
+  <legend class="user-settings-label">Have snippets be private by default?</legend>
   <input id="private-yes" type="radio" name="private" value="yes"
          {% if user.private_snippets %}checked{% endif %}>
          <label for="private-yes">yes</label>
@@ -46,7 +49,7 @@
 </fieldset>
 
 <fieldset class="user-settings-block">
-  <legend class="user-settings-label">Receive reminder emails?:</legend>
+  <legend class="user-settings-label">Receive reminder emails?</legend>
   <input id="reminder-email-yes" type="radio" name="reminder_email" value="yes"
          {% if user.wants_email %}checked{% endif %}>
          <label for="reminder-email-yes">yes</label>
@@ -65,6 +68,7 @@
     (TODO(csilvers): this field is currently ignored)<br>
   </div>
 </div>
+{% endif %}
 
 <input type="hidden" name="redirect_to" value="{{redirect_to}}">
 


### PR DESCRIPTION
The slackbot integration assumes a strict list of items in markdown format -- our version now supports manipulating a list of items in the context of a possibly longer snippet. So, in the common case where somebody wants to list out their items from Last Week and This Week separately, slackbot will find the first list of items and add/remove/display that list while ignoring and preserving any other snippet text.

Fast and dirty changes -- still need to clean up tests, etc.

Minor updates to templates w/ simplified onboarding (for our use case).